### PR TITLE
Add A/B testing middleware

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,2 +1,9 @@
 /// <reference path="../.astro/types.d.ts" />
 /// <reference types="astro/client" />
+declare global {
+  namespace App {
+      interface Locals {
+        variations: String[];
+      }
+  }
+}

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,0 +1,76 @@
+
+
+
+import {defineMiddleware} from "astro/middleware";
+
+const experiments = [
+  {
+    paths: ["/blog"],
+    name: "new-blog-headline-text",
+    variation: ["A", "B"]
+  },
+  {
+    paths: ["/blog"],
+    name: "blog-signup-cta",
+    variation: ["show", "hide"]
+  }
+]
+
+export const onRequest = defineMiddleware(async (context, next) => {
+  // pull the request and locals objects out of the context
+  const {request, locals} = context
+
+  // create an object to store the variations
+  locals.variations = locals.variations || {}
+
+  // parse the url so we can check the path
+  const url = new URL(request.url)
+
+  // check if we have an experiment that matches the current path
+  const routeExperiments = experiments.filter((exp) => exp.paths.includes(url.pathname))
+
+  if (routeExperiments.length === 0) {
+    // no experiment on this route, continue to next middleware in the chain
+    return next()
+  }
+
+  let response
+  let cookiesToSet = []
+
+  for (const experiment of routeExperiments) {
+    // check if the user already has a cookie for this experiment (meaning they've already been assigned a variation)
+    const cookie = request.headers.get("cookie")?.split(";").find((c) => c.trim().startsWith(experiment.name))
+
+    if (!cookie) {
+      // if there is no cookie, this is a new user and we need to a variation to send them to
+
+      // pick a random variation using any algorithm you want
+      const variation = experiment.variation[Math.floor(Math.random() * experiment.variation.length)]
+
+      // set the variation on the locals object so we can access it in our page
+      locals.variations[experiment.name] = variation
+
+      // remember our cookie
+      cookiesToSet.push(`${experiment.name}=${variation}`)
+    } else {
+      // if we get here, the user already has a cookie, so we can just use that variation
+      const variation = cookie?.split("=")[1]
+
+      // set the variation on the locals object so we can access it in our page
+      locals.variations[experiment.name] = variation
+    }
+  }
+
+  // render the page
+  response = await next()
+
+  // if we have cookies to set, add them to the response
+  if (cookiesToSet.length > 0) {
+    cookiesToSet.map((cookie) => {
+      response.headers.append("Set-Cookie", cookie)
+    })
+  }
+
+  // return the response to stop the middleware chain
+  return response
+})

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,41 +1,36 @@
 ---
-import BaseHead from '../../components/BaseHead.astro';
-import Header from '../../components/Header.astro';
-import Footer from '../../components/Footer.astro';
-import { SITE_TITLE, SITE_DESCRIPTION } from '../../consts';
-import { getCollection } from 'astro:content';
-import FormattedDate from '../../components/FormattedDate.astro';
+import BaseHead from "../../components/BaseHead.astro";
+import Header from "../../components/Header.astro";
+import Footer from "../../components/Footer.astro";
+import { SITE_TITLE, SITE_DESCRIPTION } from "../../consts";
+import { getCollection } from "astro:content";
+import FormattedDate from "../../components/FormattedDate.astro";
 
-const posts = (await getCollection('blog')).sort(
+const posts = (await getCollection("blog")).sort(
 	(a, b) => a.data.pubDate.valueOf() - b.data.pubDate.valueOf()
 );
+
+const { variations } = Astro.locals;
 ---
 
 <!DOCTYPE html>
 <html lang="en">
 	<head>
 		<BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} />
-		<style>
-			ul {
-				list-style-type: none;
-				padding: unset;
-			}
-			ul li {
-				display: flex;
-			}
-			ul li :global(time) {
-				flex: 0 0 130px;
-				font-style: italic;
-				color: #595959;
-			}
-			ul li a:visited {
-				color: #8e32dc;
-			}
-		</style>
 	</head>
 	<body>
 		<Header />
 		<main>
+			{
+				variations["new-blog-headline-text"] === "A" ? (
+					<h1>Meet the app that revolutionized reading.</h1>
+				) : (
+					<h1>Meet the app that has 18 million users.</h1>
+				)
+			}
+
+			{variations["blog-signup-cta"] === "show" && <button>Sign up!</button>}
+
 			<section>
 				<ul>
 					{


### PR DESCRIPTION
This PR adds a simple middleware function for running experiments on users. Please read the accompanying PDF in my submission for a detailed breakdown of the approach.

Here is a demo video of this PR in action where I am loading the page to show a variation, then clearing the site data to try and load one of the other variations.


https://github.com/cartogram/blinkist-code-challenge/assets/462077/342a3a3a-e89a-41e2-acb5-0b0196827940



